### PR TITLE
Handle nested JSON within arrays

### DIFF
--- a/__tests__/json-table.js
+++ b/__tests__/json-table.js
@@ -4,6 +4,7 @@ import { mount, shallow, render, configure } from 'enzyme';
 import Adapter from 'enzyme-adapter-react-16';
 import nock from 'nock';
 import JsonTable from '../src/JsonTable';
+import JsonToHtml from '../src/JsonToHtml';
 
 configure({ 
   adapter: new Adapter()
@@ -102,5 +103,64 @@ describe('JsonTable', function() {
     expect(() => {
       shallow(<JsonTable json={json} indent={indent} />);
     }).toThrow();
+  });
+
+  it('renders nested objects within a single array entry without [object Object]', function() {
+    const json = {
+      metadata: [
+        {
+          id: 'abc-123',
+          details: {
+            owner: 'Alice',
+            tags: ['first', 'second']
+          }
+        }
+      ]
+    };
+
+    const html = JsonToHtml.getTable(json);
+
+    expect(html).not.toContain('[object Object]');
+    expect(html).toContain('owner');
+    expect(html).toContain('Alice');
+    expect(html).toContain('tags');
+    expect(html).toContain('first');
+    expect(html).toContain('second');
+  });
+
+  it('renders nested objects within multi-entry arrays without [object Object]', function() {
+    const json = {
+      people: [
+        {
+          name: 'Alice',
+          contact: {
+            email: 'alice@example.com',
+            address: {
+              city: 'Seattle',
+              zip: '98101'
+            }
+          }
+        },
+        {
+          name: 'Bob',
+          contact: {
+            email: 'bob@example.com',
+            address: {
+              city: 'Denver',
+              zip: '80202'
+            }
+          }
+        }
+      ]
+    };
+
+    const wrapper = render(<JsonTable json={json} />);
+    const htmlOutput = wrapper.html();
+
+    expect(htmlOutput).not.toContain('[object Object]');
+    expect(htmlOutput).toContain('Alice');
+    expect(htmlOutput).toContain('alice@example.com');
+    expect(htmlOutput).toContain('Bob');
+    expect(htmlOutput).toContain('Denver');
   });
 });


### PR DESCRIPTION
## Summary
- update JsonToHtml array rendering to recursively render nested objects/arrays without leaving [object Object] placeholders
- add helpers to format primitive values consistently
- add regression tests covering nested objects in single and multi-entry arrays

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68ca7afadfa8833398626e8a674576ff