### PR TITLE
Build package before publishing

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -48,6 +48,9 @@ jobs:
           git push
           git push --tags
 
+      - name: Build package
+        run: npm run build
+
       - name: Publish to NPM
         run: npm publish --access=public
         env:

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -6,6 +6,12 @@ const babel = require('gulp-babel');
 const shell = require('gulp-shell');
 const del = require('del');
 
+const [nodeMajor] = process.versions.node.split('.').map((value) => parseInt(value, 10));
+if (Number.isInteger(nodeMajor) && nodeMajor >= 17) {
+  const existingOptions = process.env.NODE_OPTIONS ? `${process.env.NODE_OPTIONS} ` : '';
+  process.env.NODE_OPTIONS = `${existingOptions}--openssl-legacy-provider`.trim();
+}
+
 gulp.task('clean-build', function() {
   return del(['./dist/*.js']);
 });

--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "main": "dist/App.js",
   "scripts": {
     "test": "jest",
-    "git-deploy": "gulp build && gh-pages -d demo/public"
+    "build": "gulp build",
+    "git-deploy": "npm run build && gh-pages -d demo/public"
   },
   "repository": "https://github.com/mohsalsaleem/react-json-to-html.git",
   "homepage": "",

--- a/webpack.config.build-demo.js
+++ b/webpack.config.build-demo.js
@@ -11,6 +11,7 @@ module.exports = {
   output: {
     path: path.resolve(__dirname, './demo/public'),
     filename: 'demo.js',
+    hashFunction: 'sha256',
   },
   module: {
     rules: [{

--- a/webpack.config.demo.js
+++ b/webpack.config.demo.js
@@ -11,6 +11,7 @@ module.exports = {
   output: {
     path: path.resolve(__dirname, './demo'),
     filename: '[name].bundle.js',
+    hashFunction: 'sha256',
   },
   module: {
     rules: [{


### PR DESCRIPTION
## Summary
- run the gulp `build` task directly from package.json and set the OpenSSL compatibility flag inside the gulpfile when required
- update the publish workflow to build the package before running npm publish
- reuse the shared build script in the git deploy command
- configure the webpack demo builds to use the sha256 hash function to avoid legacy OpenSSL requirements

## Testing
- npm run build
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68ca9832317c833388e0bf220725fc3a