### PR TITLE
Push demo build to gh-pages branch

### DIFF
--- a/.github/workflows/deploy-demo.yml
+++ b/.github/workflows/deploy-demo.yml
@@ -6,24 +6,14 @@ on:
       - master
 
 permissions:
-  contents: read
-  pages: write
-  id-token: write
-
-concurrency:
-  group: 'pages'
-  cancel-in-progress: false
+  contents: write
 
 jobs:
-  build:
+  deploy:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-
-
 
       - name: Set up Node.js
         uses: actions/setup-node@v4
@@ -36,12 +26,9 @@ jobs:
       - name: Build demo
         run: npx gulp build
 
-      - name: Setup Pages
-        uses: actions/configure-pages@v5
-
-      - name: Upload artifact
-        uses: actions/upload-pages-artifact@v3
+      - name: Deploy to gh-pages branch
+        uses: peaceiris/actions-gh-pages@v3
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
-          publish_dir: ./demo/public
           publish_branch: gh-pages
+          publish_dir: ./demo/public


### PR DESCRIPTION
## Summary
- build the demo as part of the deploy workflow
- push the generated demo/public directory to the gh-pages branch using the gh-pages action

## Testing
- not run (workflow change only)


------
https://chatgpt.com/codex/tasks/task_e_68caba2dfdc083338dde0185228e4276